### PR TITLE
Add fluent-bit definition for shoot logs externalization

### DIFF
--- a/charts/controller/templates/_helpers.tpl
+++ b/charts/controller/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+A common name for fluent-bit resources
+*/}}
+{{- define "fluent-bit.name" -}}
+{{- default "fluent-bit" .Values.fluentbit.name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels for fluent-bit resources
+*/}}
+{{- define "fluent-bit.labels" -}}
+app.kubernetes.io/name: {{ include "fluent-bit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.fluentbit.labels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels for fluent-bit resources
+*/}}
+{{- define "fluent-bit.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "fluent-bit.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Fluent Bit Operator enabled label for selector matching
+*/}}
+{{- define "fluent-bit.enabledLabel" -}}
+{{ include "fluent-bit.name" . }}.fluent.io/enabled: "true"
+{{- end }}
+
+{{/*
+Common labels for fluent-bit resources
+*/}}
+{{- define "fluent-bit.annotations" -}}
+{{- with .Values.fluentbit.annotations }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}

--- a/charts/controller/templates/fluent-bit-clusterfluentbitconfig.yaml
+++ b/charts/controller/templates/fluent-bit-clusterfluentbitconfig.yaml
@@ -1,0 +1,32 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterFluentBitConfig
+metadata:
+  name: {{ include "fluent-bit.name" . }}-config
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+spec:
+  configFileFormat: yaml
+  namespace: {{ .Release.Namespace }}
+  service:
+    daemon: false
+    flushSeconds: {{ .Values.fluentbit.config.flushSeconds }}
+    logLevel: {{ .Values.fluentbit.config.logLevel }}
+    {{- if .Values.fluentbit.config.httpServer }}
+    httpServer: {{ .Values.fluentbit.config.httpServer }}
+    httpListen: {{ .Values.fluentbit.config.httpListen | quote }}
+    httpPort: {{ .Values.fluentbit.config.httpPort }}
+    {{- end }}
+    parsersFile: parsers.conf
+  multilineParserSelector: {}
+  parserSelector:
+    matchLabels:
+      {{- include "fluent-bit.enabledLabel" . | nindent 6 }}
+  inputSelector:
+    matchLabels:
+      {{- include "fluent-bit.enabledLabel" . | nindent 6 }}
+  filterSelector:
+    matchLabels:
+      {{- include "fluent-bit.enabledLabel" . | nindent 6 }}
+  outputSelector:
+    matchLabels:
+      {{- include "fluent-bit.enabledLabel" . | nindent 6 }}

--- a/charts/controller/templates/fluent-bit-clusterinput.yaml
+++ b/charts/controller/templates/fluent-bit-clusterinput.yaml
@@ -1,0 +1,28 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterInput
+metadata:
+  name: {{ include "fluent-bit.name" . }}-tail
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+    {{- include "fluent-bit.enabledLabel" . | nindent 4 }}
+spec:
+  tail:
+    tag: kubernetes.*
+    db: /var/fluentbit/flb_kube.db
+    dbSync: Normal
+    path: '/var/log/containers/*_shoot--*_*.log'
+    ignoredOlder: 30m
+    memBufLimit: 60MB
+    parser: fluent-bit-extension-otelcol-parser
+    pauseOnChunksOverlimit: "on"
+    refreshIntervalSeconds: 10
+    skipLongLines: true
+  processors:
+    logs:
+      - name: lua
+        code: |
+          function add_tag_to_record(tag, timestamp, record)
+            record["tag"] = tag
+            return 1, timestamp, record
+          end
+        call: add_tag_to_record

--- a/charts/controller/templates/fluent-bit-clusteroutput.yaml
+++ b/charts/controller/templates/fluent-bit-clusteroutput.yaml
@@ -1,0 +1,47 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterOutput
+metadata:
+  name: {{ include "fluent-bit.name" . }}-output
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+    {{- include "fluent-bit.enabledLabel" . | nindent 4 }}
+spec:
+  customPlugin:
+    yamlConfig:
+       name: gardener
+       match: "kubernetes.*"
+       LogLevel: debug
+       retry_Limit: 10
+       seed_type: noop
+       shoot_type: otlp_grpc
+       endpoint: ":4317"
+       insecure: true
+
+       watch_open_telemetry_collector: true
+       open_telemetry_collector_label_selector: '{"matchLabels":{"observability.gardener.cloud/app":"external-otelcol"}}'
+       open_telemetry_collector_namespace_label_selector: '{"matchLabels":{"gardener.cloud/role":"shoot"}}'
+
+
+       dynamic_host_path: '{"kubernetes": {"namespace_name": "namespace"}}'
+       dynamic_host_prefix: external-otelcol-collector.
+       dynamic_host_suffix: .svc.cluster.local:4317
+       dynamic_host_regex: "^shoot-"
+
+       use_sdk_batch_processor: true
+       sdk_batch_max_queue_size: 2048
+       sdk_batch_export_timeout: 30s
+       sdk_batch_export_interval: 1s
+       sdk_batch_export_max_batch_size: 512
+
+       retry_enabled: true
+       retry_initial_interval: 1s
+       retry_max_interval: 5m
+       retry_max_elapsed_time: 15m
+
+       origin: seed
+       tag_key: tag
+
+       fallback_to_tag_when_metadata_is_missing: true
+       send_logs_to_seed_when_shoot_is_in_hibernated_state: false
+       send_logs_to_shoot_when_is_in_deletion_state: false
+

--- a/charts/controller/templates/fluent-bit-clusterparser.yaml
+++ b/charts/controller/templates/fluent-bit-clusterparser.yaml
@@ -1,0 +1,15 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: ClusterParser
+metadata:
+  name: {{ include "fluent-bit.name" . }}-parser
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+    {{- include "fluent-bit.enabledLabel" . | nindent 4 }}
+spec:
+  decoders:
+    - decodeFieldAs: json log
+  regex:
+    regex: ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
+    timeFormat: '%Y-%m-%dT%H:%M:%S.%L%z'
+    timeKeep: true
+    timeKey: time

--- a/charts/controller/templates/fluent-bit-fluentbit.yaml
+++ b/charts/controller/templates/fluent-bit-fluentbit.yaml
@@ -1,0 +1,108 @@
+apiVersion: fluentbit.fluent.io/v1alpha2
+kind: FluentBit
+metadata:
+  name: {{ include "fluent-bit.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}
+  annotations:
+    {{- include "fluent-bit.annotations" . | nindent 4 }}
+spec:
+  fluentBitConfigName: {{ include "fluent-bit.name" . }}-config
+  {{- with .Values.fluentbit.podLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.fluentbit.podAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  initContainers:
+  - command:
+    - /bin/cp
+    - /source/plugins/.
+    - /plugins
+    image: {{ .Values.fluentbit.pluginImage.name }}
+    {{- with .Values.fluentbit.pluginImage.pullPolicy }}
+    imagePullPolicy: {{ . }}
+    {{- end }}
+    name: install-plugin
+    securityContext:
+      allowPrivilegeEscalation: false
+    volumeMounts:
+      - mountPath: /plugins
+        name: plugins
+  command:
+    - /fluent-bit/bin/fluent-bit-watcher
+    - -e
+    - /fluent-bit/plugins/output_plugin.so
+    - -c
+    - /fluent-bit/config/fluent-bit.yaml
+  envVars:
+    - name: OTEL_GO_X_OBSERVABILITY
+      value: "true"
+  image: {{ .Values.fluentbit.image.name }}
+  {{- with .Values.fluentbit.image.pullPolicy }}
+  imagePullPolicy: {{ . }}
+  {{- end }}
+  {{- with .Values.fluentbit.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.fluentbit.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  ports:
+    - containerPort: 2021
+      name: metrics-plugin
+      protocol: TCP
+  positionDB: {}
+  priorityClassName: {{ .Values.fluentbit.priorityClassName }}
+  rbacRules:
+    - apiGroups:
+        - ""
+      resources:
+        - namespaces
+      verbs: ["get", "list", "watch"]
+    - apiGroups:
+        - opentelemetry.io
+      resources:
+        - opentelemetrycollectors
+      verbs: [ "get", "list", "watch" ]
+  {{- with .Values.fluentbit.readinessProbe }}
+  readinessProbe:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.fluentbit.livenessProbe }}
+  livenessProbe:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  service:
+    name: {{ include "fluent-bit.name" . }}
+    {{- with .Values.fluentbit.service.labels }}
+    labels:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.fluentbit.service.annotations }}
+    annotations:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  disableLogVolumes: true
+  volumesMounts:
+    - mountPath: /var/fluentbit
+      name: varfluentbit
+    - mountPath: /fluent-bit/plugins
+      name: plugins
+    - mountPath: /var/log
+      name: varlog
+      readOnly: true
+  volumes:
+    - hostPath:
+        path: /var/fluentbit
+      name: varfluentbit
+    - hostPath:
+        path: /var/log
+      name: varlog
+    - emptyDir: {}
+      name: plugins

--- a/charts/controller/templates/fluent-bit-serviceaccount.yaml
+++ b/charts/controller/templates/fluent-bit-serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "fluent-bit.name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "fluent-bit.labels" . | nindent 4 }}

--- a/charts/controller/templates/service.yaml
+++ b/charts/controller/templates/service.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.extension.name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  annotations:
+    networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"port":8080,"protocol":"TCP"}]'
+    networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'
+    networking.resources.gardener.cloud/pod-label-selector-namespace-alias: "extensions"
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -14,6 +18,12 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    {{- if .Values.extension.metrics.enable_scraping }}
+    - port: 8080
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ .Values.extension.name }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/controller/templates/service.yaml
+++ b/charts/controller/templates/service.yaml
@@ -8,7 +8,9 @@ metadata:
     app.kubernetes.io/name: {{ .Values.extension.name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   annotations:
-    networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"port":8080,"protocol":"TCP"}]'
+    {{- if .Values.extension.metrics.enable_scraping }}
+    networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"port":{{ trimPrefix ":" .Values.extension.metrics.bind_address }},"protocol":"TCP"}]'
+    {{- end }}
     networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'
     networking.resources.gardener.cloud/pod-label-selector-namespace-alias: "extensions"
 spec:
@@ -19,7 +21,7 @@ spec:
       protocol: TCP
       name: http
     {{- if .Values.extension.metrics.enable_scraping }}
-    - port: 8080
+    - port: {{ trimPrefix ":" .Values.extension.metrics.bind_address }}
       targetPort: metrics
       protocol: TCP
       name: metrics

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -209,3 +209,93 @@ volumeMounts: []
 nodeSelector: {}
 tolerations: []
 affinity: {}
+# Fluent Bit Operator managed resources configuration
+fluentbit:
+  # Enable or disable Fluent Bit deployment
+  enabled: false
+  # Name of the FluentBit resource
+  name: fluent-bit-extension-otelcol
+  # Fluent Bit image
+  image:
+    name: europe-docker.pkg.dev/gardener-project/releases/3rd/fluent-operator/fluent-bit:v4.2.3
+    pullPolicy: IfNotPresent
+  # Fluent Bit Plugins image
+  # europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-plugin:v1.3.0
+  pluginImage:
+    name: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-plugin:v1.3.0
+    pullPolicy: IfNotPresent
+  labels:
+  annotations:
+  # Fluent bit pod probes configuration
+  #
+  # Check the following link for more details.
+  #
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  readinessProbe:
+    httpGet:
+      path: /api/v2/metrics/prometheus
+      port: 2020
+    periodSeconds: 10
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: 2021
+    initialDelaySeconds: 120
+    periodSeconds: 60
+  # Resources limits and requests
+  #
+  # Check the following link for more details.
+  #
+  # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+  resources:
+    requests:
+      memory: 256Mi
+    limits:
+      memory: 650Mi
+  # Fluent-bit pods additional labels
+  #
+  # Check the following link for more details about labels.
+  #
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels:
+    networking.resources.gardener.cloud/to-all-shoots-external-otelcol-collector-tcp-4317: "allowed"
+    networking.gardener.cloud/to-dns: allowed
+    networking.gardener.cloud/to-runtime-apiserver: allowed
+  # Fluent-bit pods additional annotations
+  podAnnotations:
+  # Fluent-bit pods tolerations for running on all nodes
+  #
+  # Check the following link for more details about annotations.
+  #
+  # https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+      effect: NoSchedule
+  # Fluent-bit pods priority class name
+  priorityClassName: gardener-system-600
+  # Fluent Bit Service settings.
+  #
+  # Check the following link for more details.
+  #
+  # https://kubernetes.io/docs/concepts/services-networking/service/
+  service:
+    annotations:
+      networking.resources.gardener.cloud/from-all-seed-scrape-targets-allowed-ports: '[{"port":2020,"protocol":"TCP"},{"port":2021,"protocol":"TCP"}]'
+      networking.resources.gardener.cloud/namespace-selectors: '[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]'
+      networking.resources.gardener.cloud/pod-label-selector-namespace-alias: "extensions"
+  # Fluent Bit configuration  settings
+  config:
+    # Set the flush time in seconds.nanoseconds.
+    flushSeconds: 30
+    # Fluent Bit log level. Valid values are off, error, warn, info, debug, and trace
+    logLevel: info
+    # HTTP server for health checks and metrics.
+    httpServer: true
+    # Set listening interface for HTTP Server when it's enabled.
+    httpListen: "0.0.0.0"
+    # Set TCP Port for the HTTP Server.
+    httpPort: 2020

--- a/examples/dev-setup/controllerregistration.yaml
+++ b/examples/dev-setup/controllerregistration.yaml
@@ -4,7 +4,7 @@ kind: ControllerRegistration
 metadata:
   name: otelcol
   annotations:
-    security.gardener.cloud/pod-security-enforce: baseline
+    security.gardener.cloud/pod-security-enforce: privileged
 spec:
   # https://gardener.cloud/docs/gardener/extensions/registration/#deployment-configuration-options
   deployment:

--- a/examples/operator-extension/patches/extension.yaml
+++ b/examples/operator-extension/patches/extension.yaml
@@ -3,7 +3,7 @@ kind: Extension
 metadata:
   name: otelcol
   annotations:
-    security.gardener.cloud/pod-security-enforce: baseline
+    security.gardener.cloud/pod-security-enforce: privileged
 spec:
   deployment:
     extension:

--- a/pkg/actuator/actuator.go
+++ b/pkg/actuator/actuator.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -143,6 +144,9 @@ const (
 	// memoryLimiterProcessorName is the name of the OpenTelemetry Memory
 	// Limiter processor name.
 	memoryLimiterProcessorName = "memory_limiter"
+
+	// resourceProcessorName is the name of the OpenTelemetry Resource processor.
+	resourceProcessorName = "resource"
 )
 
 // Actuator is an implementation of [extension.Actuator].
@@ -967,6 +971,23 @@ func (a *Actuator) getOtelExporters(cfg config.CollectorConfig) map[string]any {
 	return exporters
 }
 
+// parseShootNamespaceAttributes extracts OTel resource attributes from a shoot
+// namespace name of the form "shoot--<project>--<shoot>".
+// The full namespace name maps to k8s.cluster.name; the two segments map to
+// gardener.project.name and gardener.shoot.name respectively.
+// For namespaces that do not follow the pattern, projectName and shootName are
+// returned as empty strings.
+func parseShootNamespaceAttributes(namespace string) (clusterName, projectName, shootName string) {
+	clusterName = namespace
+	parts := strings.SplitN(namespace, "--", 3)
+	if len(parts) == 3 {
+		projectName = parts[1]
+		shootName = parts[2]
+	}
+
+	return clusterName, projectName, shootName
+}
+
 // getOTelCollector returns the [otelv1beta1.OpenTelemetryCollector]
 // resource, which the extension manages.
 func (a *Actuator) getOtelCollector(
@@ -994,6 +1015,7 @@ func (a *Actuator) getOtelCollector(
 
 	exporters := a.getOtelExporters(cfg)
 	exporterNames := slices.Sorted(maps.Keys(exporters))
+	clusterName, projectName, shootName := parseShootNamespaceAttributes(namespace)
 	allLabels := utils.MergeStringMaps(
 		a.getCommonLabels(),
 		a.getNetworkLabels(),
@@ -1094,6 +1116,13 @@ func (a *Actuator) getOtelCollector(
 							"limit_percentage":       a.memoryLimiterConfig.MemoryLimitPercentage,
 							"spike_limit_percentage": a.memoryLimiterConfig.MemorySpikePercentage,
 						},
+						resourceProcessorName: map[string]any{
+							"attributes": []any{
+								map[string]any{"key": "k8s.cluster.name", "value": clusterName, "action": "upsert"},
+								map[string]any{"key": "gardener.project.name", "value": projectName, "action": "upsert"},
+								map[string]any{"key": "gardener.shoot.name", "value": shootName, "action": "upsert"},
+							},
+						},
 					},
 				},
 				Exporters: otelv1beta1.AnyConfig{
@@ -1126,12 +1155,12 @@ func (a *Actuator) getOtelCollector(
 					Pipelines: map[string]*otelv1beta1.Pipeline{
 						"logs": {
 							Receivers:  []string{"otlp"},
-							Processors: []string{memoryLimiterProcessorName, batchProcessorName},
+							Processors: []string{resourceProcessorName, memoryLimiterProcessorName, batchProcessorName},
 							Exporters:  exporterNames,
 						},
 						"metrics": {
 							Receivers:  []string{"prometheus"},
-							Processors: []string{memoryLimiterProcessorName, batchProcessorName},
+							Processors: []string{resourceProcessorName, memoryLimiterProcessorName, batchProcessorName},
 							Exporters:  exporterNames,
 						},
 					},

--- a/pkg/actuator/actuator.go
+++ b/pkg/actuator/actuator.go
@@ -1008,7 +1008,7 @@ func (a *Actuator) getOtelCollector(
 				a.getAnnotations(),
 				map[string]string{
 					resourcesv1alpha1.NetworkPolicyLabelKeyPrefix + "pod-label-selector-namespace-alias": "all-shoots",
-					resourcesv1alpha1.NetworkPolicyLabelKeyPrefix + "namespace-selectors":                `[{"matchLabels":{"kubernetes.io/metadata.name":"garden"}}]`,
+					resourcesv1alpha1.NetworkPolicyLabelKeyPrefix + "namespace-selectors":                `[{"matchExpressions":[{"key":"kubernetes.io/metadata.name","operator":"In","values":["garden"]}]},{"matchExpressions":[{"key":"gardener.cloud/role","operator":"In","values":["extension"]}]}]`,
 				}),
 		},
 		Spec: otelv1beta1.OpenTelemetryCollectorSpec{

--- a/pkg/actuator/actuator_namespace_test.go
+++ b/pkg/actuator/actuator_namespace_test.go
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package actuator
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("parseShootNamespaceAttributes", func() {
+	DescribeTable("should parse the namespace into OTel resource attributes",
+		func(namespace, wantCluster, wantProject, wantShoot string) {
+			cluster, project, shoot := parseShootNamespaceAttributes(namespace)
+			Expect(cluster).To(Equal(wantCluster))
+			Expect(project).To(Equal(wantProject))
+			Expect(shoot).To(Equal(wantShoot))
+		},
+		Entry("standard shoot namespace",
+			"shoot--my-project--my-shoot",
+			"shoot--my-project--my-shoot", "my-project", "my-shoot",
+		),
+		Entry("shoot name containing hyphens",
+			"shoot--local--my-complex-shoot-name",
+			"shoot--local--my-complex-shoot-name", "local", "my-complex-shoot-name",
+		),
+		Entry("non-shoot namespace returns empty project and shoot",
+			"kube-system",
+			"kube-system", "", "",
+		),
+		Entry("only two segments returns empty project and shoot",
+			"shoot--local",
+			"shoot--local", "", "",
+		),
+	)
+})


### PR DESCRIPTION
##  What this PR does / why we need it:

Adds Fluent Bit deployment support to the otelcol extension using the Fluent Bit Operator CRDs.
Fluent Bit runs as a DaemonSet that tails shoot container logs and forwards them via the gardener
custom output plugin to per-shoot OTel Collectors over gRPC.

Changes include:

- Helm templates for FluentBit, ClusterFluentBitConfig, ClusterInput, ClusterOutput, ClusterParser and ServiceAccount
- Template helpers (_helpers.tpl) for common labels, names, and annotations
- Default values in values.yaml (disabled by default via fluentbit.enabled: false)
- Networking annotations and metrics port on the controller service
- Fix OTel Collector namespace-selectors annotation to use matchExpressions with OR semantics (matching garden namespace OR extension role namespaces)
- Update pod-security-enforce from baseline to privileged in examples (required for host path mounts)

## Special notes:

- The Fluent Bit deployment is disabled by default and must be explicitly enabled via fluentbit.enabled: true
- The gardener custom output plugin image is currently using a snapshot (v1.3.0-dev-1650edbd) — this should be updated to a release image before merging
- Pod security is set to privileged because Fluent Bit requires host path volume mounts (/var/log,/var/fluentbit) for log collection
- The namespace-selectors annotation on the OTel Collector now uses two separate selector objects in the array to achieve OR semantics (each array element is OR'd by Gardener's network policy controller)
- This PR depends on fluent-bit-plugin release 1.3.0. It brings https://github.com/gardener/logging/pull/462 

```feature user
Add Fluent Bit DaemonSet deployment for log collection and forwarding to per-shoot OpenTelemetry Collectors via the gardener output plugin.
```
