### PR TITLE
Collect shoot cluster events via k8sobjects receiver

### DIFF
--- a/charts/controller/templates/fluent-bit-clusterinput.yaml
+++ b/charts/controller/templates/fluent-bit-clusterinput.yaml
@@ -11,6 +11,7 @@ spec:
     db: /var/fluentbit/flb_kube.db
     dbSync: Normal
     path: '/var/log/containers/*_shoot--*_*.log'
+    excludePath: '/var/log/containers/*_shoot--*_event-logger_*.log'
     ignoredOlder: 30m
     memBufLimit: 60MB
     parser: fluent-bit-extension-otelcol-parser

--- a/charts/controller/values.yaml
+++ b/charts/controller/values.yaml
@@ -222,7 +222,7 @@ fluentbit:
   # Fluent Bit Plugins image
   # europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-plugin:v1.3.0
   pluginImage:
-    name: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-plugin:v1.3.0
+    name: europe-docker.pkg.dev/gardener-project/releases/gardener/fluent-bit-plugin:v1.4.0
     pullPolicy: IfNotPresent
   labels:
   annotations:

--- a/examples/opentelemetry-receiver.yaml
+++ b/examples/opentelemetry-receiver.yaml
@@ -184,6 +184,32 @@ data:
             auth:
               authenticator: bearertokenauth/server
 
+    connectors:
+      routing:
+        default_pipelines: [logs/string]
+        error_mode: ignore
+        table:
+          - context: log
+            condition: IsMap(body)
+            pipelines: [logs/objects]
+
+    processors:
+      batch: {}
+
+      # For k8s objects — set _msg from map fields
+      transform/objects:
+        log_statements:
+          - context: log
+            statements:
+              - 'set(attributes["_msg"], Concat([body["object"]["metadata"]["namespace"], "/", body["object"]["metadata"]["name"]], ""))'
+
+      # For string logs — _msg = body directly
+      transform/string:
+        log_statements:
+          - context: log
+            statements:
+              - 'set(attributes["_msg"], body)'
+
     exporters:
       debug:
         verbosity: basic
@@ -205,20 +231,22 @@ data:
                     port: 8888
       pipelines:
         metrics:
-          exporters:
-            - debug
-          receivers:
-            - otlp
-        logs:
-          exporters:
-            - debug
-          receivers:
-            - otlp
+          receivers: [otlp]
+          exporters: [debug]
         traces:
-          exporters:
-            - debug
-          receivers:
-            - otlp
+          receivers: [otlp]
+          exporters: [debug]
+        logs/fanin:
+          receivers: [otlp]
+          exporters: [routing]
+        logs/objects:
+          receivers: [routing]
+          processors: [transform/objects, batch]
+          exporters: [debug]
+        logs/string:
+          receivers: [routing]
+          processors: [transform/string, batch]
+          exporters: [debug]
 ---
 apiVersion: v1
 kind: Service

--- a/pkg/actuator/actuator.go
+++ b/pkg/actuator/actuator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerfeatures "github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/utils"
+	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
 	imagevectorutils "github.com/gardener/gardener/pkg/utils/imagevector"
 	kubernetesutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
@@ -122,6 +123,22 @@ const (
 	// targetAllocatorConfigMapName is the name of the ConfigMap for the
 	// Target Allocator.
 	targetAllocatorConfigMapName = baseResourceName + "-targetallocator-config"
+
+	// transformEventsProcessorName is the name of the transform processor for
+	// the k8sobjects/events pipeline.
+	transformEventsProcessorName = "transform/events"
+
+	// shootAccessSecretName is the name of the shoot access secret used by the
+	// k8sobjects/events receiver to authenticate to the shoot cluster.
+	shootAccessSecretName = "shoot-access-" + otelCollectorName // #nosec: G101
+
+	// shootManagedResourceName is the name of the ManagedResource that deploys
+	// RBAC into the shoot cluster for the k8sobjects/events receiver.
+	shootManagedResourceName = baseResourceName + "-shoot"
+
+	// volumeNameShootKubeconfig is the volume name for the shoot kubeconfig
+	// projected into the OTel Collector pod for the k8sobjects/events receiver.
+	volumeNameShootKubeconfig = "shoot-kubeconfig"
 
 	// bearertokenauthextension names used by the exporters.
 	baseBearerTokenAuthName         = "bearertokenauth"
@@ -412,6 +429,13 @@ func (a *Actuator) Reconcile(ctx context.Context, logger logr.Logger, ex *extens
 		return err
 	}
 
+	shootKubeconfigSecretName := extensionscontroller.GenericTokenKubeconfigSecretNameFromCluster(cluster)
+
+	shootAccessSecret := gardenerutils.NewShootAccessSecret(shootAccessSecretName, ex.Namespace)
+	if err := shootAccessSecret.Reconcile(ctx, a.client); err != nil {
+		return fmt.Errorf("failed reconciling shoot access secret: %w", err)
+	}
+
 	data, err := registry.AddAllAndSerialize(
 		taConfigMap,
 		a.getTargetAllocatorServiceAccount(ex.Namespace),
@@ -426,12 +450,32 @@ func (a *Actuator) Reconcile(ctx context.Context, logger logr.Logger, ex *extens
 			clientSecret,
 			cfg,
 			cluster.Shoot.Spec.Resources,
+			shootKubeconfigSecretName,
+			shootAccessSecret.Secret.Name,
 			collectorImage,
 		),
 	)
 
 	if err != nil {
 		return err
+	}
+
+	shootRegistry := managedresources.NewRegistry(
+		kubernetes.ShootScheme,
+		kubernetes.ShootCodec,
+		kubernetes.ShootSerializer,
+	)
+
+	shootData, err := shootRegistry.AddAllAndSerialize(
+		a.getEventsClusterRole(),
+		a.getEventsClusterRoleBinding(shootAccessSecret.ServiceAccountName),
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := managedresources.CreateForShoot(ctx, a.client, ex.Namespace, shootManagedResourceName, Name, false, shootData); err != nil {
+		return fmt.Errorf("failed creating shoot managed resource: %w", err)
 	}
 
 	return managedresources.CreateForSeed(
@@ -458,6 +502,18 @@ func (a *Actuator) Delete(ctx context.Context, logger logr.Logger, ex *extension
 		return fmt.Errorf("failed cleaning up secrets managed by secrets manager: %w", err)
 	}
 
+	if err := client.IgnoreNotFound(managedresources.DeleteForShoot(ctx, a.client, ex.Namespace, shootManagedResourceName)); err != nil {
+		return fmt.Errorf("failed deleting shoot managed resource: %w", err)
+	}
+
+	if err := managedresources.WaitUntilDeleted(ctx, a.client, ex.Namespace, shootManagedResourceName); err != nil {
+		return fmt.Errorf("failed waiting for shoot managed resource to be deleted: %w", err)
+	}
+
+	if err := client.IgnoreNotFound(a.client.Delete(ctx, gardenerutils.NewShootAccessSecret(shootAccessSecretName, ex.Namespace).Secret)); err != nil {
+		return fmt.Errorf("failed deleting shoot access secret: %w", err)
+	}
+
 	return client.IgnoreNotFound(managedresources.DeleteForSeed(ctx, a.client, ex.Namespace, managedResourceName))
 }
 
@@ -476,11 +532,20 @@ func (a *Actuator) Restore(ctx context.Context, logger logr.Logger, ex *extensio
 	return a.Reconcile(ctx, logger, ex)
 }
 
-// Migrate signals the [Actuator] to reconcile the resources managed by it,
+// Migrate signals the [Actuator] to migrate the resources managed by it,
 // because of a shoot control-plane migration event. This method implements the
 // [extension.Actuator] interface.
+//
+// Shoot-scoped resources (RBAC) must be preserved on the shoot cluster so the
+// target seed can pick them up after migration. SetKeepObjects prevents the
+// ManagedResource controller from deleting them when the ManagedResource is
+// removed from the old seed.
 func (a *Actuator) Migrate(ctx context.Context, logger logr.Logger, ex *extensionsv1alpha1.Extension) error {
-	return a.Reconcile(ctx, logger, ex)
+	if err := managedresources.SetKeepObjects(ctx, a.client, ex.Namespace, shootManagedResourceName, true); err != nil {
+		return fmt.Errorf("failed setting keep-objects on shoot managed resource: %w", err)
+	}
+
+	return a.Delete(ctx, logger, ex)
 }
 
 func (a *Actuator) newSecretsManager(ctx context.Context, log logr.Logger, namespace string) (secretsmanager.Interface, error) {
@@ -995,6 +1060,8 @@ func (a *Actuator) getOtelCollector(
 	caSecret, clientSecret *corev1.Secret,
 	cfg config.CollectorConfig,
 	resources []gardencorev1beta1.NamedResourceReference,
+	shootKubeconfigSecretName string,
+	accessSecretName string,
 	image *imagevectorutils.Image,
 ) *otelv1beta1.OpenTelemetryCollector {
 	const (
@@ -1051,11 +1118,17 @@ func (a *Actuator) getOtelCollector(
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: volumeNameCACertificate, MountPath: volumeMountPathCACertificate, ReadOnly: true},
 					{Name: volumeNameClientCertificate, MountPath: volumeMountPathClientCertificate, ReadOnly: true},
+					{Name: volumeNameShootKubeconfig, MountPath: gardenerutils.VolumeMountPathGenericKubeconfig, ReadOnly: true},
 				},
 				Volumes: []corev1.Volume{
 					{Name: volumeNameCACertificate, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: caSecret.Name}}},
 					{Name: volumeNameClientCertificate, VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: clientSecret.Name}}},
+					gardenerutils.GenerateGenericKubeconfigVolume(shootKubeconfigSecretName, accessSecretName, volumeNameShootKubeconfig),
 				},
+				Env: []corev1.EnvVar{{
+					Name:  "KUBECONFIG",
+					Value: gardenerutils.PathGenericKubeconfig,
+				}},
 				PriorityClassName: v1beta1constants.PriorityClassNameShootControlPlane100,
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
@@ -1100,6 +1173,16 @@ func (a *Actuator) getOtelCollector(
 								},
 							},
 						},
+						"k8sobjects/events": map[string]any{
+							"auth_type": "kubeConfig",
+							"objects": []any{
+								map[string]any{
+									"name":  "events",
+									"group": "events.k8s.io",
+									"mode":  "watch",
+								},
+							},
+						},
 					},
 				},
 				Processors: &otelv1beta1.AnyConfig{
@@ -1121,6 +1204,16 @@ func (a *Actuator) getOtelCollector(
 								map[string]any{"key": "k8s.cluster.name", "value": clusterName, "action": "upsert"},
 								map[string]any{"key": "gardener.project.name", "value": projectName, "action": "upsert"},
 								map[string]any{"key": "gardener.shoot.name", "value": shootName, "action": "upsert"},
+							},
+						},
+						transformEventsProcessorName: map[string]any{
+							"log_statements": []any{
+								map[string]any{
+									"context": "log",
+									"statements": []any{
+										`delete_key(body["object"]["metadata"], "managedFields")`,
+									},
+								},
 							},
 						},
 					},
@@ -1156,6 +1249,11 @@ func (a *Actuator) getOtelCollector(
 						"logs": {
 							Receivers:  []string{"otlp"},
 							Processors: []string{resourceProcessorName, memoryLimiterProcessorName, batchProcessorName},
+							Exporters:  exporterNames,
+						},
+						"logs/events": {
+							Receivers:  []string{"k8sobjects/events"},
+							Processors: []string{resourceProcessorName, memoryLimiterProcessorName, transformEventsProcessorName, batchProcessorName},
 							Exporters:  exporterNames,
 						},
 						"metrics": {
@@ -1212,6 +1310,43 @@ func (a *Actuator) getOtelCollector(
 	)
 
 	return obj
+}
+
+// getEventsClusterRole returns the [rbacv1.ClusterRole] granting the OTel
+// Collector's service account in the shoot cluster permission to list and watch
+// events from the events.k8s.io API group.
+func (a *Actuator) getEventsClusterRole() *rbacv1.ClusterRole {
+	return &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: otelCollectorName,
+		},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{"events.k8s.io"},
+			Resources: []string{"events"},
+			Verbs:     []string{"get", "list", "watch"},
+		}},
+	}
+}
+
+// getEventsClusterRoleBinding returns the [rbacv1.ClusterRoleBinding] that
+// binds the events ClusterRole to the OTel Collector's service account in the
+// shoot cluster's kube-system namespace.
+func (a *Actuator) getEventsClusterRoleBinding(serviceAccountName string) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: otelCollectorName,
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     otelCollectorName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      serviceAccountName,
+			Namespace: metav1.NamespaceSystem,
+		}},
+	}
 }
 
 func secretNameForResource(resourceName string, resources []gardencorev1beta1.NamedResourceReference) string {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

Shoot cluster events (`events.k8s.io/v1`) are currently collected by the proprietary `event-logger` component, which tails container logs and emits events in a non-standard, Gardener-specific log format. This format is opaque to upstream observability tooling and makes it impossible to forward shoot events to external OTel-native backends without custom parsing.

This PR replaces that approach by adding a `k8sobjects` receiver to the OTel Collector that watches `events.k8s.io/v1` events directly from the shoot API server in real time (watch mode). Events are emitted as structured OTel log records, enriched with standard resource attributes, and forwarded through the existing exporter pipeline — fully compatible with any upstream OTel-native receiver without any custom parsing or format translation.

As a consequence, the Fluent Bit `ClusterInput` is updated to explicitly exclude `event-logger` container logs from collection, since events are now sourced directly via the k8sobjects receiver.

**Changes:**

- **Shoot access secret**: A `ShootAccessSecret` (`shoot-access-otelcol`) is reconciled in the shoot namespace. Gardener's token projector keeps this secret's kubeconfig up to date with a short-lived token, giving the Collector a secure, auto-rotating credential to the shoot API server.

- **Shoot RBAC** (`ManagedResource: <namespace>-shoot`): A `ClusterRole` + `ClusterRoleBinding` is deployed into the shoot cluster granting `get/list/watch` on `events.k8s.io/events` to the Collector's service account. Only the minimum required permissions are requested.

- **Kubeconfig volume**: The shoot generic kubeconfig (projected secret + access token) is mounted into the Collector pod at `gardenerutils.VolumeMountPathGenericKubeconfig`, and `KUBECONFIG` is set to `gardenerutils.PathGenericKubeconfig` so the `k8sobjects` receiver picks it up automatically via `auth_type: kubeConfig`.

- **`k8sobjects/events` receiver**: Configured with `auth_type: kubeConfig`, watching `events.k8s.io/events` in watch mode for low-latency delivery.

- **`transform/events` processor**: Strips `managedFields` from the event body before forwarding, reducing payload size and noise.

- **`logs/events` pipeline**: `k8sobjects/events → resource → memoryLimiter → transform/events → batch → exporters`. The resource processor enriches events with `k8s.cluster.name`, `gardener.project.name`, and `gardener.shoot.name` — the same attributes already applied to all other signals.

- **Lifecycle correctness**:
  - `Delete`: shoot `ManagedResource` is deleted and waited on before the shoot access secret is removed, ensuring the `ManagedResource` controller can still authenticate to the shoot while cleaning up the RBAC objects.
  - `Migrate`: calls `SetKeepObjects(true)` on the shoot `ManagedResource` before delegating to `Delete`, so the shoot RBAC objects are preserved on the shoot cluster during control-plane migration and the target seed can take ownership without re-creating them.

- **Fluent Bit** (separate commit): excludes `event-logger` container logs from the `ClusterInput` (pattern `*_shoot--*_event-logger_*.log`) since events are now collected via the k8sobjects receiver. Also bumps the plugin image to `v1.4.0`.

- **Example** (separate commit): adds a routing connector to `examples/opentelemetry-receiver.yaml` that splits incoming logs by body type — structured k8s object logs vs plain string logs — with dedicated `transform` processors setting `_msg`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

- Only `events.k8s.io/v1` events are collected — core `v1.Event` (legacy API group `""`) is intentionally excluded as modern Kubernetes components write exclusively to `events.k8s.io`.
- The `k8sobjects` receiver uses `auth_type: kubeConfig` which reads `$KUBECONFIG`. This is the standard Gardener pattern for shoot-cluster access from seed workloads.
- The shoot `ManagedResource` uses `keepObjects: false` during normal operation; `SetKeepObjects(true)` is set only transiently during `Migrate` before the resource is deleted from the old seed.
- To verify the receiver is active after reconciliation, port-forward the Collector's metrics endpoint and check the receiver metrics:
  \`\`\`bash
  kubectl -n shoot--local--local port-forward statefulset/otelcol 8888:8888
  curl -s localhost:8888/metrics | grep -E 'receiver="k8sobjects/events"'
  \`\`\`
  A non-zero \`otelcol_receiver_accepted_log_records_total{receiver="k8sobjects/events"}\` confirms events are being received.

**Release note**:
\`\`\`feature operator
Replace proprietary event-logger-based shoot event collection with the OTel
k8sobjects receiver. Events are now collected directly from the shoot API server
as structured OTel log records (events.k8s.io/v1), enriched with cluster,
project, and shoot name attributes, and forwarded in standard OTel format to
any configured upstream receiver without custom parsing.
\`\`\`