### PR TITLE
chore(deps): group go.opentelemetry.io/collector/* renovate updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,5 +8,13 @@
   ],
   "postUpdateOptions": [
     "gomodTidy"
+  ],
+  "packageRules": [
+    {
+      "groupName": "otel-collector",
+      "groupSlug": "otel-collector",
+      "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["go.opentelemetry.io/collector/"]
+    }
   ]
 }


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

Adds a Renovate `packageRule` that bundles every `go.opentelemetry.io/collector/*` gomod update into a single PR (group name `otel-collector`).

Upstream OpenTelemetry Collector releases version all `collector/*` modules in lockstep, so the previous one-PR-per-module pattern produced redundant churn — for example #113 (`batchprocessor` → v0.152.0) and #114 (`memorylimiterprocessor` → v0.152.0) would have been a single PR with this rule in place.

The rule is scoped to `gomod` to avoid affecting Helm/Docker image bumps, and intentionally does not include `go.opentelemetry.io/otel/*` (instrumentation SDK) which versions on a different cadence.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

After merge, Renovate will recreate the open `collector/*` PRs (currently #113, #114) as a single grouped PR on the next run.

**Release note**:
```other dependency
Renovate now groups all `go.opentelemetry.io/collector/*` gomod updates into a single PR.
```