### PR TITLE
feat: add TLS reload_interval for OTLP exporters

### DIFF
--- a/docs/api-reference/otelcol.extensions.gardener.cloud.md
+++ b/docs/api-reference/otelcol.extensions.gardener.cloud.md
@@ -365,5 +365,6 @@ _Appears in:_
 | `ca` _[ResourceReference](#resourcereference)_ | CA references the CA certificate to use for verifying the server certificate.<br />For a client this verifies the server certificate.<br />For a server this verifies client certificates.<br />If empty uses system root CA. |  | Optional: \{\} <br /> |
 | `cert` _[ResourceReference](#resourcereference)_ | Cert references the client certificate to use for TLS required connections. |  | Optional: \{\} <br /> |
 | `key` _[ResourceReference](#resourcereference)_ | Key references the client key to use for TLS required connections. |  | Optional: \{\} <br /> |
+| `reloadInterval` _[Duration](#duration)_ | ReloadInterval specifies mTLS key and cert reload interval<br />from mounted secret volume | <nil> | Optional: \{\} <br /> |
 
 

--- a/pkg/actuator/actuator.go
+++ b/pkg/actuator/actuator.go
@@ -975,6 +975,8 @@ func (a *Actuator) getOTLPHTTPExporterConfig(cfg config.OTLPHTTPExporterConfig) 
 			tlsConfig["key_file"] = filepath.Join(httpExporterVolumeMountPathTLS, tls.Key.ResourceRef.DataKey)
 		}
 
+		tlsConfig["reload_interval"] = tls.ReloadInterval.String()
+
 		exporter["tls"] = tlsConfig
 	}
 
@@ -1029,6 +1031,8 @@ func (a *Actuator) getOTLPGRPCExporterConfig(cfg config.OTLPGRPCExporterConfig) 
 		if tls.Key != nil {
 			tlsConfig["key_file"] = filepath.Join(grpcExporterVolumeMountPathTLS, tls.Key.ResourceRef.DataKey)
 		}
+
+		tlsConfig["reload_interval"] = tls.ReloadInterval.String()
 
 		exporter["tls"] = tlsConfig
 	}

--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -348,6 +348,9 @@ type TLSConfig struct {
 	Cert *ResourceReference
 	// Key references the client key to use for TLS required connections.
 	Key *ResourceReference
+	// ReloadInterval specifies the duration after which the certificate will be reloaded.
+	// If not set, it will never be reloaded
+	ReloadInterval time.Duration
 }
 
 // ResourceReference references data from a Secret.

--- a/pkg/apis/config/v1alpha1/generated.conversion.go
+++ b/pkg/apis/config/v1alpha1/generated.conversion.go
@@ -473,6 +473,7 @@ func autoConvert_v1alpha1_TLSConfig_To_config_TLSConfig(in *TLSConfig, out *conf
 	out.CA = (*config.ResourceReference)(unsafe.Pointer(in.CA))
 	out.Cert = (*config.ResourceReference)(unsafe.Pointer(in.Cert))
 	out.Key = (*config.ResourceReference)(unsafe.Pointer(in.Key))
+	out.ReloadInterval = time.Duration(in.ReloadInterval)
 	return nil
 }
 
@@ -486,6 +487,7 @@ func autoConvert_config_TLSConfig_To_v1alpha1_TLSConfig(in *config.TLSConfig, ou
 	out.CA = (*ResourceReference)(unsafe.Pointer(in.CA))
 	out.Cert = (*ResourceReference)(unsafe.Pointer(in.Cert))
 	out.Key = (*ResourceReference)(unsafe.Pointer(in.Key))
+	out.ReloadInterval = time.Duration(in.ReloadInterval)
 	return nil
 }
 

--- a/pkg/apis/config/v1alpha1/generated.defaults.go
+++ b/pkg/apis/config/v1alpha1/generated.defaults.go
@@ -29,6 +29,9 @@ func SetObjectDefaults_CollectorConfig(in *CollectorConfig) {
 			var ptrVar1 bool = false
 			in.Spec.Exporters.OTLPGRPCExporter.TLS.InsecureSkipVerify = &ptrVar1
 		}
+		if in.Spec.Exporters.OTLPGRPCExporter.TLS.ReloadInterval == 0 {
+			in.Spec.Exporters.OTLPGRPCExporter.TLS.ReloadInterval = time.Duration(DefaultTLSReloadInterval)
+		}
 	}
 	if in.Spec.Exporters.OTLPGRPCExporter.Timeout == 0 {
 		in.Spec.Exporters.OTLPGRPCExporter.Timeout = time.Duration(DefaultGRPCExporterClientTimeout)
@@ -66,6 +69,9 @@ func SetObjectDefaults_CollectorConfig(in *CollectorConfig) {
 		if in.Spec.Exporters.OTLPHTTPExporter.TLS.InsecureSkipVerify == nil {
 			var ptrVar1 bool = false
 			in.Spec.Exporters.OTLPHTTPExporter.TLS.InsecureSkipVerify = &ptrVar1
+		}
+		if in.Spec.Exporters.OTLPHTTPExporter.TLS.ReloadInterval == 0 {
+			in.Spec.Exporters.OTLPHTTPExporter.TLS.ReloadInterval = time.Duration(DefaultTLSReloadInterval)
 		}
 	}
 	if in.Spec.Exporters.OTLPHTTPExporter.Timeout == 0 {

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -134,6 +134,14 @@ const (
 	// DefaultGRPCExporterClientWriteBufferSize specifies the default
 	// WriteBufferSize for the gRPC client used by the exporters.
 	DefaultGRPCExporterClientWriteBufferSize = 32 * 1024
+
+	// DefaultTLSReloadInterval specifies the default interval at which the
+	// OTel Collector re-reads TLS material (CA, client cert, client key)
+	// from disk. Without it, the collector loads the certs once at startup
+	// and keeps using the in-memory copy even after the backing Secret is
+	// rotated, leading to handshake failures with an expired client cert
+	// until the pod is restarted.
+	DefaultTLSReloadInterval = 30 * time.Second
 )
 
 // RetryOnFailureConfig provides the retry policy for an exporter.
@@ -473,6 +481,12 @@ type TLSConfig struct {
 	//
 	// +k8s:optional
 	Key *ResourceReference `json:"key,omitempty"`
+	// ReloadInterval specifies mTLS key and cert reload interval
+	// from mounted secret volume
+	//
+	// +k8s:optional
+	// +default=ref(DefaultTLSReloadInterval)
+	ReloadInterval time.Duration `json:"reloadInterval,omitzero"`
 }
 
 // ResourceReference references data from a Secret.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:

This PR adds `reloadInterval` field in `TLSConfig`.
Generated `OpenTelemetryCollector` will contain `tls.reload_interval` and thus mTLS certificates and keys are reloaded upon update.

Reference in  [OTel `configtls` docs](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md):

> `reload_interval` (optional): ReloadInterval specifies the duration after
> which the certificate will be reloaded. If not set, it will never be
> reloaded.

Defaults to `30s`; the defaulter  guarantees rotation.

**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
```feature user
The OTLP HTTP and gRPC exporter TLS config now supports a `reloadInterval`
field. Defaults to `30s`, so rotated certs are picked up automatically.
```
